### PR TITLE
Use kube v1.1 with schemars v0.8 like kube itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license = "MIT"
 repository = "https://github.com/commercetools/kuberator"
 
 [dependencies]
-kube = { version = "1.0", features = ["runtime", "derive"] }
+kube = { version = "1.1", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.25", features = ["latest"] }
 
 futures = { version = "0.3", default-features = false }
 async-trait = "0.1"
 
-schemars = "0.9"
+schemars = "0.8"
 serde = { version = "1.0", features = ["derive", "rc"] }
 
 log = { version = "0.4", features = ["kv", "kv_serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuberator"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@gmail.com>"]
 description = "Crate to simplify writing an k8s operator"


### PR DESCRIPTION
Use the actual version of `kube` together with the `kube` used version of `schemars`. Schemars v0.9 is not working yet with `kube`.