### PR TITLE
Migrate EventRecorder to events.k8s.io/v1 with deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-02-13
+
+### Added
+- Event deduplication via in-memory cache: identical events (same object UID, type, reason, action) within a 6-minute window are PATCHed with an incremented `series.count` instead of creating new Event objects
+- `EventRecorder::with_cache_ttl()` builder method to customize the deduplication window
+- Automatic note truncation to 1024 characters (the `events.k8s.io/v1` field limit), with `...` suffix on truncation
+- Action field defaults to the reason string when not explicitly set via `with_action()`
+- `RecordedEvent<R>` struct in `MockEventRecorder` with `resource_name`, `reason`, `message`, and `count` fields
+- `MockEventRecorder::event_count()` convenience method
+
+### Changed
+- **BREAKING**: Migrated from `core/v1/Event` to `events.k8s.io/v1/Event` API ([migration guide](MIGRATION_v0.4.md))
+- **BREAKING**: `EventRecorder<P>` now requires `P: ProvideApi<events::v1::Event>` (was `core::v1::Event`)
+- **BREAKING**: `MockEventRecorder::events()` returns `Vec<RecordedEvent<R>>` instead of `Vec<(String, R, String)>`
+- **BREAKING**: RBAC rules must include `apiGroups: ["events.k8s.io"]` with verbs `create, patch`
+- Added `tokio` as a runtime dependency (sync feature, for async-safe dedup cache)
+
 ## [0.3.1] - 2026-01-05
 
 ### Added
@@ -103,7 +120,8 @@ see the [commit history](https://github.com/maoertel/kuberator/commits/main).
 
 ---
 
-[Unreleased]: https://github.com/maoertel/kuberator/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/maoertel/kuberator/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/maoertel/kuberator/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/maoertel/kuberator/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/maoertel/kuberator/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/maoertel/kuberator/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuberator"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@gmail.com>"]
 description = "A Kubernetes operator framework in Rust"
@@ -20,6 +20,7 @@ async-trait = "0.1"
 schemars = "1.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 
+tokio = { version = "1.0", features = ["sync"] }
 tracing = "0.1"
 
 thiserror = "2.0"

--- a/MIGRATION_v0.4.md
+++ b/MIGRATION_v0.4.md
@@ -1,0 +1,142 @@
+# Migration Guide: v0.3 → v0.4
+
+## Breaking Change: Event API migrated to `events.k8s.io/v1` with deduplication
+
+Kuberator v0.4 replaces the legacy `core/v1/Event` API with `events.k8s.io/v1` and adds built-in event deduplication. Identical events are now collapsed into a single Event object with an incrementing series count instead of flooding the API server with duplicates.
+
+## Why This Change?
+
+Operators that emit events on every reconciliation cycle (e.g., every 15 seconds for persistent errors) create ~240 duplicate events per hour. This floods `kubectl describe` output, loads the API server, and makes it hard to find meaningful events.
+
+**Benefits you gain:**
+- **Deduplication**: Identical events within a 6-minute window are PATCHed (incrementing `series.count`) instead of CREATEd
+- **Clean output**: `kubectl events` shows `(x52 over 13m)` instead of 52 separate lines
+- **Reduced API load**: One PATCH vs one CREATE per repeated event
+- **Note truncation**: Messages exceeding the 1024-character `events.k8s.io/v1` limit are automatically truncated with `...`
+- **Action defaulting**: The required `action` field defaults to the reason string when not explicitly set
+
+## Migration Steps
+
+### Step 1: Update import
+
+Change the Event type in your `StaticApiProvider` type signatures:
+
+```rust
+// Before
+use k8s_openapi::api::core::v1::Event;
+
+// After
+use k8s_openapi::api::events::v1::Event;
+```
+
+This typically affects:
+- Your operator setup code where `StaticApiProvider<Event>` is constructed
+- Type aliases or struct fields referencing `EventRecorder<StaticApiProvider<Event>>`
+
+### Step 2: Update RBAC / ClusterRole
+
+The `events.k8s.io/v1` API requires its own RBAC rules. Add the new rule alongside the existing one during transition:
+
+```yaml
+rules:
+  # Legacy core/v1 events (keep during transition)
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # New events.k8s.io/v1 (required for kuberator v0.4)
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+```
+
+After all deployments are running v0.4, you can remove the legacy `core/v1` rule.
+
+### Step 3: Update test code
+
+If you use `MockEventRecorder` in tests, update field access:
+
+```rust
+// Before (tuple access)
+let events = recorder.events();
+assert_eq!(events[0].0, "resource-name");  // name
+assert_eq!(events[0].1, MyReason::Created); // reason
+assert_eq!(events[0].2, "message");         // message
+
+// After (struct fields)
+let events = recorder.events();
+assert_eq!(events[0].resource_name, "resource-name");
+assert_eq!(events[0].reason, MyReason::Created);
+assert_eq!(events[0].message, "message");
+assert_eq!(events[0].count, 1); // dedup count
+```
+
+The mock now deduplicates events the same way the real recorder does: same `resource_name` + `reason` increments `count` instead of creating a new entry.
+
+## New Features
+
+### Event Deduplication
+
+Events with the same (object UID, event type, reason, action) are automatically deduplicated within a 6-minute window. The first occurrence creates a new Event; subsequent identical events PATCH the existing Event's `series.count`.
+
+This happens transparently - no code changes needed in your event emission logic.
+
+### Customizing the Dedup Window
+
+```rust
+use std::time::Duration;
+
+let event_recorder = EventRecorder::new(event_api_provider, "my-operator")
+    .with_cache_ttl(Duration::from_secs(10 * 60)); // 10 minutes
+```
+
+After the TTL expires, the next emission creates a fresh Event object.
+
+### Action Field
+
+The `events.k8s.io/v1` API requires the `action` field. If you don't set it via `with_action()`, it defaults to the reason string (e.g., `"DriftDetected"`, `"ReconciliationFailed"`).
+
+To set a custom action:
+
+```rust
+EventData::normal(MyReason::ResourceCreated, "Resource created")
+    .with_action("Reconcile")
+```
+
+### Note Truncation
+
+Messages longer than 1024 characters are automatically truncated with a `...` suffix, respecting UTF-8 character boundaries. No action needed.
+
+## Viewing Events
+
+Events created via `events.k8s.io/v1` are best viewed with:
+
+```bash
+# Recommended - shows events.k8s.io/v1, sorted by time, with dedup counts
+kubectl events -n <namespace>
+
+# Filter for a specific resource
+kubectl events -n <namespace> --for <kind>/<name>
+
+# Also works - kubectl describe aggregates from both APIs
+kubectl describe <kind> <name> -n <namespace>
+```
+
+Note: `kubectl get events` only shows legacy `core/v1` events. Use `kubectl events` (without `get`) for the new API.
+
+## Troubleshooting
+
+### "Forbidden" errors in operator logs
+
+Your ClusterRole is missing the `events.k8s.io` RBAC rule. See Step 2 above.
+
+### "action: Required value" errors
+
+You're running kuberator v0.4.0 code but the `action` field isn't being set. This was fixed in the initial release - make sure you're on the latest commit.
+
+### Events not showing in `kubectl get events`
+
+Use `kubectl events` instead. The `get events` command only queries the legacy `core/v1` API.
+
+### Old duplicate events still visible
+
+Events created before the migration (via `core/v1`) remain until they expire (default TTL is 1 hour in most clusters). New events will be deduplicated.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ building Kubernetes Operators. It is still in its early stages and a work in pro
 - **Trait-based Architecture** - Clean separation of concerns with `Finalize`, `Context`, and `Reconcile` traits
 - **API Caching** - Lock-free caching strategies for optimal performance (Strict, Adhoc, Extendable)
 - **Generic Repository** - Zero-boilerplate `K8sRepository` implementation
-- **Event Emission** - Built-in Kubernetes Event creation for observability
+- **Event Emission** - Built-in Kubernetes Event creation via `events.k8s.io/v1` with automatic deduplication
 - **Status Management** - Observed Generation Pattern with error handling support
 - **Graceful Shutdown** - Signal-based controller termination
 - **Concurrent Reconciliation** - Configurable parallelism with `start_concurrent()`
@@ -232,7 +232,12 @@ reconciler.start(Some(shutdown_signal)).await;
 
 ## Event Emission
 
-Emit Kubernetes Events for observability. Events appear in `kubectl describe` output and provide visibility into operator operations.
+Emit Kubernetes Events via the `events.k8s.io/v1` API with built-in deduplication. Events appear in
+`kubectl describe` and `kubectl events` output and provide visibility into operator operations.
+
+Identical events (same object, type, reason, and action) within a 6-minute window are automatically
+deduplicated: the first occurrence creates a new Event, subsequent ones PATCH the existing Event's
+`series.count`.
 
 ### Quick Example
 
@@ -250,7 +255,7 @@ enum MyEventReason {
 
 impl Reason for MyEventReason {}
 
-// Setup event recorder
+// Setup event recorder (note: use events::v1::Event, not core::v1::Event)
 let event_api_provider = Arc::new(StaticApiProvider::new(
     client.clone(),
     vec!["default"],
@@ -270,6 +275,24 @@ event_recorder.emit(
 ```
 
 Events never fail reconciliation—errors are logged as warnings. Use `MockEventRecorder` for testing.
+
+### RBAC Requirements
+
+Your operator's ClusterRole needs permission to create and patch events in the `events.k8s.io` API group:
+
+```yaml
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+```
+
+### Viewing Events
+
+Use `kubectl events` (not `kubectl get events`) to see `events.k8s.io/v1` events with dedup counts:
+
+```bash
+kubectl events -n <namespace> --for <kind>/<name>
+```
 
 See [module documentation](https://docs.rs/kuberator/latest/kuberator/events/) for detailed usage.
 

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -98,7 +98,8 @@ pub mod tests {
     use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
     use std::sync::Arc;
     use std::sync::Mutex;
-    use strum::{AsRefStr, Display};
+    use strum::AsRefStr;
+    use strum::Display;
 
     // Test event reason enum
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, AsRefStr)]

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -3,6 +3,10 @@
 //! This module provides generic event emission functionality for Kubernetes operators.
 //! Events are observability-only and never fail reconciliation.
 //!
+//! Events use the `events.k8s.io/v1` API with built-in deduplication: the first
+//! occurrence creates a new Event, and subsequent identical events increment the
+//! series count via PATCH instead of creating duplicates.
+//!
 //! # Example
 //! ```rust,ignore
 //! use kuberator::events::{EmitEvent, EventRecorder, EventData, Reason};
@@ -107,10 +111,19 @@ pub mod tests {
 
     impl Reason for TestEventReason {}
 
-    /// Mock event recorder for testing
+    /// A recorded event with deduplication tracking
+    #[derive(Debug, Clone)]
+    pub struct RecordedEvent<R: Reason> {
+        pub resource_name: String,
+        pub reason: R,
+        pub message: String,
+        pub count: i32,
+    }
+
+    /// Mock event recorder for testing with deduplication behavior
     #[derive(Clone)]
     pub struct MockEventRecorder<R: Reason> {
-        events: Arc<Mutex<Vec<(String, R, String)>>>,
+        events: Arc<Mutex<Vec<RecordedEvent<R>>>>,
     }
 
     impl<R: Reason> Default for MockEventRecorder<R> {
@@ -126,8 +139,14 @@ pub mod tests {
             }
         }
 
-        pub fn events(&self) -> Vec<(String, R, String)> {
+        /// Returns deduplicated events with counts
+        pub fn events(&self) -> Vec<RecordedEvent<R>> {
             self.events.lock().unwrap().clone()
+        }
+
+        /// Returns the number of unique events
+        pub fn event_count(&self) -> usize {
+            self.events.lock().unwrap().len()
         }
 
         pub fn clear(&self) {
@@ -141,10 +160,26 @@ pub mod tests {
         where
             K: Resource<DynamicType = ()> + TryResource + Clone + Send + Sync,
         {
-            self.events
-                .lock()
-                .unwrap()
-                .push((object.try_name()?.to_owned(), event.reason, event.message));
+            let name = object.try_name()?.to_owned();
+            let reason_str = event.reason.as_ref().to_owned();
+
+            let mut events = self.events.lock().unwrap();
+
+            // Dedup: find existing event with same resource_name + reason
+            if let Some(existing) = events
+                .iter_mut()
+                .find(|e| e.resource_name == name && e.reason.as_ref() == reason_str)
+            {
+                existing.count += 1;
+                existing.message = event.message;
+            } else {
+                events.push(RecordedEvent {
+                    resource_name: name,
+                    reason: event.reason,
+                    message: event.message,
+                    count: 1,
+                });
+            }
 
             Ok(())
         }
@@ -153,7 +188,7 @@ pub mod tests {
     /// Mock that can be configured to fail on demand for testing error handling
     struct FailingMockEventRecorder<R: Reason> {
         should_fail: bool,
-        events: Arc<Mutex<Vec<(String, R, String)>>>,
+        events: Arc<Mutex<Vec<RecordedEvent<R>>>>,
     }
 
     impl<R: Reason> FailingMockEventRecorder<R> {
@@ -171,7 +206,7 @@ pub mod tests {
             }
         }
 
-        fn events(&self) -> Vec<(String, R, String)> {
+        fn events(&self) -> Vec<RecordedEvent<R>> {
             self.events.lock().unwrap().clone()
         }
     }
@@ -186,10 +221,25 @@ pub mod tests {
                 return Err(Error::EmitEventFailed("Simulated failure".to_string()));
             }
 
-            self.events
-                .lock()
-                .unwrap()
-                .push((object.try_name()?.to_owned(), event.reason, event.message));
+            let name = object.try_name()?.to_owned();
+            let reason_str = event.reason.as_ref().to_owned();
+
+            let mut events = self.events.lock().unwrap();
+
+            if let Some(existing) = events
+                .iter_mut()
+                .find(|e| e.resource_name == name && e.reason.as_ref() == reason_str)
+            {
+                existing.count += 1;
+                existing.message = event.message;
+            } else {
+                events.push(RecordedEvent {
+                    resource_name: name,
+                    reason: event.reason,
+                    message: event.message,
+                    count: 1,
+                });
+            }
 
             Ok(())
         }
@@ -208,10 +258,11 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_mock_event_recorder() {
+        // Given: A mock event recorder and a resource
         let recorder = MockEventRecorder::<TestEventReason>::new();
-
         let resource = create_test_resource();
 
+        // When: Emitting a single event
         recorder
             .try_emit(
                 &resource,
@@ -220,11 +271,13 @@ pub mod tests {
             .await
             .unwrap();
 
+        // Then: One event is recorded with correct fields
         let events = recorder.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].0, "test-resource");
-        assert_eq!(events[0].1, TestEventReason::ResourceCreated);
-        assert_eq!(events[0].2, "Resource was created");
+        assert_eq!(events[0].resource_name, "test-resource");
+        assert_eq!(events[0].reason, TestEventReason::ResourceCreated);
+        assert_eq!(events[0].message, "Resource was created");
+        assert_eq!(events[0].count, 1);
     }
 
     #[test]
@@ -301,8 +354,8 @@ pub mod tests {
         assert!(result.is_ok());
         let events = recorder.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].0, "test-resource");
-        assert_eq!(events[0].2, "Test message");
+        assert_eq!(events[0].resource_name, "test-resource");
+        assert_eq!(events[0].message, "Test message");
     }
 
     #[tokio::test]
@@ -341,7 +394,7 @@ pub mod tests {
         // Then: The event was recorded (no panic, no error propagation)
         let events = recorder.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].0, "test-resource");
+        assert_eq!(events[0].resource_name, "test-resource");
     }
 
     #[tokio::test]
@@ -380,17 +433,17 @@ pub mod tests {
         // Then: try_emit was called (evidenced by recorded event)
         let events = recorder.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].1, TestEventReason::ResourceUpdated);
-        assert_eq!(events[0].2, "Update message");
+        assert_eq!(events[0].reason, TestEventReason::ResourceUpdated);
+        assert_eq!(events[0].message, "Update message");
     }
 
     #[tokio::test]
-    async fn test_multiple_events_are_recorded_sequentially() {
+    async fn test_multiple_different_events_are_recorded() {
         // Given: A recorder and a resource
         let recorder = MockEventRecorder::<TestEventReason>::new();
         let resource = create_test_resource();
 
-        // When: Emitting multiple events
+        // When: Emitting multiple events with different reasons
         recorder
             .emit(
                 &resource,
@@ -412,12 +465,12 @@ pub mod tests {
             )
             .await;
 
-        // Then: All events are recorded in order
+        // Then: All events are recorded separately (different reasons = no dedup)
         let events = recorder.events();
         assert_eq!(events.len(), 3);
-        assert_eq!(events[0].1, TestEventReason::ResourceCreated);
-        assert_eq!(events[1].1, TestEventReason::ResourceUpdated);
-        assert_eq!(events[2].1, TestEventReason::ResourceDeleted);
+        assert_eq!(events[0].reason, TestEventReason::ResourceCreated);
+        assert_eq!(events[1].reason, TestEventReason::ResourceUpdated);
+        assert_eq!(events[2].reason, TestEventReason::ResourceDeleted);
     }
 
     #[tokio::test]
@@ -440,5 +493,129 @@ pub mod tests {
 
         // Then: All events are removed
         assert_eq!(recorder.events().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_events_are_deduplicated() {
+        // Given: A recorder and a resource
+        let recorder = MockEventRecorder::<TestEventReason>::new();
+        let resource = create_test_resource();
+
+        // When: Emitting the same event (same resource + reason) twice
+        recorder
+            .emit(
+                &resource,
+                EventData::normal(TestEventReason::ResourceCreated, "First message"),
+            )
+            .await;
+
+        recorder
+            .emit(
+                &resource,
+                EventData::normal(TestEventReason::ResourceCreated, "Second message"),
+            )
+            .await;
+
+        // Then: Only one event exists with count=2 and the latest message
+        let events = recorder.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].reason, TestEventReason::ResourceCreated);
+        assert_eq!(events[0].message, "Second message");
+        assert_eq!(events[0].count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_different_reasons_not_deduplicated() {
+        // Given: A recorder and a resource
+        let recorder = MockEventRecorder::<TestEventReason>::new();
+        let resource = create_test_resource();
+
+        // When: Emitting events with different reasons for the same resource
+        recorder
+            .emit(
+                &resource,
+                EventData::normal(TestEventReason::ResourceCreated, "Created"),
+            )
+            .await;
+
+        recorder
+            .emit(
+                &resource,
+                EventData::warning(TestEventReason::ReconciliationFailed, "Failed"),
+            )
+            .await;
+
+        // Then: Both events are recorded separately
+        let events = recorder.events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].count, 1);
+        assert_eq!(events[1].count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_different_resources_not_deduplicated() {
+        // Given: A recorder and two different resources
+        let recorder = MockEventRecorder::<TestEventReason>::new();
+        let resource1 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("resource-1".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let resource2 = ConfigMap {
+            metadata: ObjectMeta {
+                name: Some("resource-2".to_string()),
+                namespace: Some("default".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // When: Emitting the same reason for different resources
+        recorder
+            .emit(
+                &resource1,
+                EventData::normal(TestEventReason::ResourceCreated, "Created 1"),
+            )
+            .await;
+
+        recorder
+            .emit(
+                &resource2,
+                EventData::normal(TestEventReason::ResourceCreated, "Created 2"),
+            )
+            .await;
+
+        // Then: Both events are recorded separately
+        let events = recorder.events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].resource_name, "resource-1");
+        assert_eq!(events[1].resource_name, "resource-2");
+    }
+
+    #[tokio::test]
+    async fn test_event_count_returns_unique_count() {
+        // Given: A recorder with some events
+        let recorder = MockEventRecorder::<TestEventReason>::new();
+        let resource = create_test_resource();
+
+        // When: Emitting 3 events (2 duplicates + 1 different)
+        recorder
+            .emit(&resource, EventData::normal(TestEventReason::ResourceCreated, "First"))
+            .await;
+        recorder
+            .emit(&resource, EventData::normal(TestEventReason::ResourceCreated, "Second"))
+            .await;
+        recorder
+            .emit(
+                &resource,
+                EventData::normal(TestEventReason::ResourceUpdated, "Updated"),
+            )
+            .await;
+
+        // Then: event_count returns 2 unique events
+        assert_eq!(recorder.event_count(), 2);
     }
 }

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -172,14 +172,15 @@ pub mod tests {
             {
                 existing.count += 1;
                 existing.message = event.message;
-            } else {
-                events.push(RecordedEvent {
-                    resource_name: name,
-                    reason: event.reason,
-                    message: event.message,
-                    count: 1,
-                });
+                return Ok(());
             }
+
+            events.push(RecordedEvent {
+                resource_name: name,
+                reason: event.reason,
+                message: event.message,
+                count: 1,
+            });
 
             Ok(())
         }
@@ -232,14 +233,15 @@ pub mod tests {
             {
                 existing.count += 1;
                 existing.message = event.message;
-            } else {
-                events.push(RecordedEvent {
-                    resource_name: name,
-                    reason: event.reason,
-                    message: event.message,
-                    count: 1,
-                });
+                return Ok(());
             }
+
+            events.push(RecordedEvent {
+                resource_name: name,
+                reason: event.reason,
+                message: event.message,
+                count: 1,
+            });
 
             Ok(())
         }

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -1,15 +1,21 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use chrono::Utc;
-use k8s_openapi::api::core::v1::Event;
-use k8s_openapi::api::core::v1::EventSource;
 use k8s_openapi::api::core::v1::ObjectReference;
+use k8s_openapi::api::events::v1::Event as K8sEvent;
+use k8s_openapi::api::events::v1::EventSeries;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use kube::api::Patch;
+use kube::api::PatchParams;
 use kube::api::PostParams;
 use kube::Resource;
+use serde::Serialize;
+use tokio::sync::Mutex;
 
 use crate::cache::ProvideApi;
 use crate::error::Result;
@@ -17,36 +23,29 @@ use crate::events::types::{EventData, Reason};
 use crate::events::EmitEvent;
 use crate::TryResource;
 
-/// Implementation of EmitEvent that creates Kubernetes Event resources
+/// Implementation of EmitEvent that creates Kubernetes Event resources using the
+/// `events.k8s.io/v1` API with built-in deduplication.
+///
+/// First occurrence of an event creates a new Event object. Subsequent identical
+/// events (same object UID, type, reason, and action) increment the series count
+/// via a PATCH instead of creating duplicate events.
+///
+/// Cache entries expire after a configurable TTL (default: 6 minutes), after which
+/// the next emission creates a fresh Event.
 pub struct EventRecorder<P>
 where
-    P: ProvideApi<Event> + Send + Sync,
+    P: ProvideApi<K8sEvent> + Send + Sync,
 {
     api_provider: Arc<P>,
     component: Cow<'static, str>,
-}
-
-impl<P> EventRecorder<P>
-where
-    P: ProvideApi<Event> + Send + Sync,
-{
-    /// Create a new EventRecorder
-    ///
-    /// # Arguments
-    /// * `api_provider` - API provider for Event resources
-    /// * `component` - Component name that will appear in events (e.g., "my-operator")
-    pub fn new(api_provider: Arc<P>, component: impl Into<Cow<'static, str>>) -> Self {
-        Self {
-            api_provider,
-            component: component.into(),
-        }
-    }
+    cache: Mutex<HashMap<EventKey, CachedEvent>>,
+    cache_ttl: Duration,
 }
 
 #[async_trait]
 impl<P, R> EmitEvent<R> for EventRecorder<P>
 where
-    P: ProvideApi<Event> + Send + Sync,
+    P: ProvideApi<K8sEvent> + Send + Sync,
     R: Reason,
 {
     #[tracing::instrument(
@@ -65,43 +64,169 @@ where
     {
         let namespace = object.try_namespace()?;
         let name = object.try_name()?;
+        let uid = object.meta().uid.to_owned().unwrap_or_default();
+        let key = EventKey::new(uid, &event);
 
-        let events = self.api_provider.get(&namespace)?;
+        let cached = self.lookup_cached(&key).await;
+        let events_api = self.api_provider.get(&namespace)?;
 
-        let now = Utc::now();
-        let event_name = format!("{name}.{now}", now = now.timestamp());
+        if let Some(cached) = cached {
+            return self.patch_existing(&events_api, &key, &cached).await;
+        }
 
-        let k8s_event = Event {
-            metadata: ObjectMeta {
-                name: Some(event_name),
-                namespace: Some(namespace.to_owned()),
-                ..Default::default()
-            },
-            involved_object: ObjectReference {
-                api_version: Some(K::api_version(&()).to_string()),
-                kind: Some(K::kind(&()).to_string()),
-                name: Some(name.to_owned()),
-                namespace: Some(namespace),
-                uid: object.meta().uid.to_owned(),
-                resource_version: object.meta().resource_version.to_owned(),
-                ..Default::default()
-            },
-            reason: Some(event.reason.to_string()),
-            message: Some(event.message),
-            type_: Some(event.type_.to_string()),
-            first_timestamp: Some(Time(now)),
-            last_timestamp: Some(Time(now)),
-            source: Some(EventSource {
-                component: Some(self.component.to_string()),
-                ..Default::default()
-            }),
-            reporting_component: Some(self.component.to_string()),
-            action: event.action,
+        let regarding = ObjectReference {
+            api_version: Some(K::api_version(&()).to_string()),
+            kind: Some(K::kind(&()).to_string()),
+            name: Some(name.to_owned()),
+            namespace: Some(namespace.clone()),
+            uid: object.meta().uid.clone(),
+            resource_version: object.meta().resource_version.clone(),
             ..Default::default()
         };
+        self.create_new(&events_api, key, event, name, &namespace, regarding)
+            .await
+    }
+}
 
-        events.create(&PostParams::default(), &k8s_event).await?;
+impl<P> EventRecorder<P>
+where
+    P: ProvideApi<K8sEvent> + Send + Sync,
+{
+    const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(6 * 60);
+
+    /// Create a new EventRecorder
+    ///
+    /// # Arguments
+    /// * `api_provider` - API provider for Event resources
+    /// * `component` - Component name that will appear in events (e.g., "my-operator")
+    pub fn new(api_provider: Arc<P>, component: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            api_provider,
+            component: component.into(),
+            cache: Mutex::new(HashMap::new()),
+            cache_ttl: Self::DEFAULT_CACHE_TTL,
+        }
+    }
+
+    /// Set a custom cache TTL for deduplication.
+    ///
+    /// Events with the same key emitted within this window are deduplicated.
+    /// After expiry, the next emission creates a new Event object.
+    pub fn with_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.cache_ttl = ttl;
+        self
+    }
+
+    async fn lookup_cached(&self, key: &EventKey) -> Option<CachedEvent> {
+        let mut cache = self.cache.lock().await;
+        let ttl = self.cache_ttl;
+        cache.retain(|_, v| v.last_emitted.elapsed() < ttl);
+        cache.get(key).cloned()
+    }
+
+    async fn patch_existing(
+        &self,
+        events_api: &kube::Api<K8sEvent>,
+        key: &EventKey,
+        cached: &CachedEvent,
+    ) -> Result<()> {
+        let new_count = cached.count + 1;
+        let now = Utc::now();
+
+        let patch = EventSeriesPatch {
+            series: EventSeries {
+                count: new_count,
+                last_observed_time: MicroTime(now),
+            },
+        };
+
+        events_api
+            .patch(&cached.event_name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+
+        let mut cache = self.cache.lock().await;
+        if let Some(entry) = cache.get_mut(key) {
+            entry.count = new_count;
+            entry.last_emitted = Instant::now();
+        }
 
         Ok(())
     }
+
+    async fn create_new<R: Reason>(
+        &self,
+        events_api: &kube::Api<K8sEvent>,
+        key: EventKey,
+        event: EventData<R>,
+        name: &str,
+        namespace: &str,
+        regarding: ObjectReference,
+    ) -> Result<()> {
+        let now = Utc::now();
+        let event_name = format!("{name}.{:x}", now.timestamp_micros() as u64);
+
+        let k8s_event = K8sEvent {
+            metadata: ObjectMeta {
+                name: Some(event_name.clone()),
+                namespace: Some(namespace.to_owned()),
+                ..Default::default()
+            },
+            event_time: Some(MicroTime(now)),
+            reporting_controller: Some(self.component.to_string()),
+            reporting_instance: Some(self.component.to_string()),
+            regarding: Some(regarding),
+            action: event.action,
+            reason: Some(event.reason.to_string()),
+            note: Some(event.message),
+            type_: Some(event.type_.to_string()),
+            ..Default::default()
+        };
+
+        events_api.create(&PostParams::default(), &k8s_event).await?;
+
+        let mut cache = self.cache.lock().await;
+        cache.insert(
+            key,
+            CachedEvent {
+                event_name,
+                count: 1,
+                last_emitted: Instant::now(),
+            },
+        );
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct EventKey {
+    object_uid: String,
+    event_type: Cow<'static, str>,
+    reason: String,
+    action: Option<String>,
+}
+
+impl EventKey {
+    fn new<R: Reason>(uid: String, event: &EventData<R>) -> Self {
+        let event_type: &'static str = event.type_.into();
+        Self {
+            object_uid: uid,
+            event_type: Cow::Borrowed(event_type),
+            reason: event.reason.to_string(),
+            action: event.action.to_owned(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CachedEvent {
+    event_name: String,
+    count: i32,
+    last_emitted: Instant,
+}
+
+/// Patch payload containing only the series field for merge-patching existing events.
+#[derive(Debug, Serialize)]
+struct EventSeriesPatch {
+    series: EventSeries,
 }

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -19,7 +20,8 @@ use tokio::sync::Mutex;
 
 use crate::cache::ProvideApi;
 use crate::error::Result;
-use crate::events::types::{EventData, Reason};
+use crate::events::types::EventData;
+use crate::events::types::Reason;
 use crate::events::EmitEvent;
 use crate::TryResource;
 

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -93,6 +93,8 @@ where
     P: ProvideApi<K8sEvent> + Send + Sync,
 {
     const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(6 * 60);
+    /// Maximum length for the `note` field in `events.k8s.io/v1` Events.
+    const MAX_NOTE_LENGTH: usize = 1024;
 
     /// Create a new EventRecorder
     ///
@@ -166,6 +168,9 @@ where
         let now = Utc::now();
         let event_name = format!("{name}.{:x}", now.timestamp_micros() as u64);
 
+        let action = event.action.unwrap_or_else(|| event.reason.to_string());
+        let note = truncate_note(event.message, Self::MAX_NOTE_LENGTH);
+
         let k8s_event = K8sEvent {
             metadata: ObjectMeta {
                 name: Some(event_name.to_owned()),
@@ -176,9 +181,9 @@ where
             reporting_controller: Some(self.component.to_string()),
             reporting_instance: Some(self.component.to_string()),
             regarding: Some(regarding),
-            action: event.action,
+            action: Some(action),
             reason: Some(event.reason.to_string()),
-            note: Some(event.message),
+            note: Some(note),
             type_: Some(event.type_.to_string()),
             ..Default::default()
         };
@@ -230,4 +235,78 @@ struct CachedEvent {
 #[derive(Debug, Serialize)]
 struct EventSeriesPatch {
     series: EventSeries,
+}
+
+/// Truncate a message to fit within the `events.k8s.io/v1` note field limit.
+/// Appends "..." when truncation occurs, preserving char boundaries.
+fn truncate_note(message: String, max_len: usize) -> String {
+    if message.len() <= max_len {
+        return message;
+    }
+
+    let suffix = "...";
+    let truncate_at = max_len - suffix.len();
+    let boundary = message
+        .char_indices()
+        .take_while(|(i, _)| *i <= truncate_at)
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+
+    format!("{}{suffix}", &message[..boundary])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_note_short_message_unchanged() {
+        // Given a message within the limit
+        let message = "Short message".to_string();
+
+        // When truncating with a generous limit
+        let result = truncate_note(message.clone(), 1024);
+
+        // Then the message is unchanged
+        assert_eq!(result, message);
+    }
+
+    #[test]
+    fn truncate_note_exact_limit_unchanged() {
+        // Given a message exactly at the limit
+        let message = "a".repeat(1024);
+
+        // When truncating
+        let result = truncate_note(message.clone(), 1024);
+
+        // Then the message is unchanged
+        assert_eq!(result, message);
+    }
+
+    #[test]
+    fn truncate_note_over_limit_adds_ellipsis() {
+        // Given a message exceeding the limit
+        let message = "a".repeat(1025);
+
+        // When truncating
+        let result = truncate_note(message, 1024);
+
+        // Then the result is truncated with "..." and fits within limit
+        assert_eq!(result.len(), 1024);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_note_preserves_char_boundaries() {
+        // Given a message with multi-byte characters near the boundary
+        let message = format!("{}ä{}", "a".repeat(1022), "b".repeat(10));
+
+        // When truncating
+        let result = truncate_note(message, 1024);
+
+        // Then the result is valid UTF-8 and within limit
+        assert!(result.len() <= 1024);
+        assert!(result.ends_with("..."));
+    }
 }

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -78,9 +78,9 @@ where
             api_version: Some(K::api_version(&()).to_string()),
             kind: Some(K::kind(&()).to_string()),
             name: Some(name.to_owned()),
-            namespace: Some(namespace.clone()),
-            uid: object.meta().uid.clone(),
-            resource_version: object.meta().resource_version.clone(),
+            namespace: Some(namespace.to_owned()),
+            uid: object.meta().uid.to_owned(),
+            resource_version: object.meta().resource_version.to_owned(),
             ..Default::default()
         };
         self.create_new(&events_api, key, event, name, &namespace, regarding)
@@ -117,6 +117,7 @@ where
         self
     }
 
+    /// Look up a cached event by key, evicting expired entries first.
     async fn lookup_cached(&self, key: &EventKey) -> Option<CachedEvent> {
         let mut cache = self.cache.lock().await;
         let ttl = self.cache_ttl;
@@ -167,7 +168,7 @@ where
 
         let k8s_event = K8sEvent {
             metadata: ObjectMeta {
-                name: Some(event_name.clone()),
+                name: Some(event_name.to_owned()),
                 namespace: Some(namespace.to_owned()),
                 ..Default::default()
             },

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -11,10 +11,10 @@ use k8s_openapi::api::events::v1::Event;
 use k8s_openapi::api::events::v1::EventSeries;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use kube::Api;
 use kube::api::Patch;
 use kube::api::PatchParams;
 use kube::api::PostParams;
+use kube::Api;
 use kube::Resource;
 use serde::Serialize;
 use tokio::sync::Mutex;
@@ -130,12 +130,7 @@ where
         cache.get(key).cloned()
     }
 
-    async fn patch_existing(
-        &self,
-        events_api: &Api<Event>,
-        key: &EventKey,
-        cached: &CachedEvent,
-    ) -> Result<()> {
+    async fn patch_existing(&self, events_api: &Api<Event>, key: &EventKey, cached: &CachedEvent) -> Result<()> {
         let new_count = cached.count + 1;
         let now = Utc::now();
 

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -11,6 +11,7 @@ use k8s_openapi::api::events::v1::Event;
 use k8s_openapi::api::events::v1::EventSeries;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::Api;
 use kube::api::Patch;
 use kube::api::PatchParams;
 use kube::api::PostParams;
@@ -131,7 +132,7 @@ where
 
     async fn patch_existing(
         &self,
-        events_api: &kube::Api<Event>,
+        events_api: &Api<Event>,
         key: &EventKey,
         cached: &CachedEvent,
     ) -> Result<()> {
@@ -160,7 +161,7 @@ where
 
     async fn create_new<R: Reason>(
         &self,
-        events_api: &kube::Api<Event>,
+        events_api: &Api<Event>,
         key: EventKey,
         event: EventData<R>,
         name: &str,

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use async_trait::async_trait;
 use chrono::Utc;
 use k8s_openapi::api::core::v1::ObjectReference;
-use k8s_openapi::api::events::v1::Event as K8sEvent;
+use k8s_openapi::api::events::v1::Event;
 use k8s_openapi::api::events::v1::EventSeries;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -36,7 +36,7 @@ use crate::TryResource;
 /// the next emission creates a fresh Event.
 pub struct EventRecorder<P>
 where
-    P: ProvideApi<K8sEvent> + Send + Sync,
+    P: ProvideApi<Event> + Send + Sync,
 {
     api_provider: Arc<P>,
     component: Cow<'static, str>,
@@ -47,7 +47,7 @@ where
 #[async_trait]
 impl<P, R> EmitEvent<R> for EventRecorder<P>
 where
-    P: ProvideApi<K8sEvent> + Send + Sync,
+    P: ProvideApi<Event> + Send + Sync,
     R: Reason,
 {
     #[tracing::instrument(
@@ -92,7 +92,7 @@ where
 
 impl<P> EventRecorder<P>
 where
-    P: ProvideApi<K8sEvent> + Send + Sync,
+    P: ProvideApi<Event> + Send + Sync,
 {
     const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(6 * 60);
     /// Maximum length for the `note` field in `events.k8s.io/v1` Events.
@@ -131,7 +131,7 @@ where
 
     async fn patch_existing(
         &self,
-        events_api: &kube::Api<K8sEvent>,
+        events_api: &kube::Api<Event>,
         key: &EventKey,
         cached: &CachedEvent,
     ) -> Result<()> {
@@ -160,7 +160,7 @@ where
 
     async fn create_new<R: Reason>(
         &self,
-        events_api: &kube::Api<K8sEvent>,
+        events_api: &kube::Api<Event>,
         key: EventKey,
         event: EventData<R>,
         name: &str,
@@ -173,7 +173,7 @@ where
         let action = event.action.unwrap_or_else(|| event.reason.to_string());
         let note = truncate_note(event.message, Self::MAX_NOTE_LENGTH);
 
-        let k8s_event = K8sEvent {
+        let k8s_event = Event {
             metadata: ObjectMeta {
                 name: Some(event_name.to_owned()),
                 namespace: Some(namespace.to_owned()),

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -2,9 +2,10 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use strum::AsRefStr;
 use strum::Display as StrumDisplay;
+use strum::IntoStaticStr;
 
 /// Type of Kubernetes event
-#[derive(Debug, Clone, Copy, PartialEq, Eq, StrumDisplay, AsRefStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, StrumDisplay, AsRefStr, IntoStaticStr)]
 pub enum EventType {
     /// Normal events represent informational messages about successful operations
     Normal,

--- a/src/events/types.rs
+++ b/src/events/types.rs
@@ -32,7 +32,6 @@ pub struct EventData<R: Reason> {
 }
 
 impl<R: Reason> EventData<R> {
-    /// Create a Normal event
     pub fn normal(reason: R, message: impl Into<String>) -> Self {
         Self {
             type_: EventType::Normal,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,8 +180,13 @@
 //!
 //! ## Event Emission
 //!
-//! Kuberator provides generic Kubernetes event emission for observability through the [`events`] module.
-//! Events appear in `kubectl describe` output and provide visibility into operator operations.
+//! Kuberator provides generic Kubernetes event emission via the `events.k8s.io/v1` API through
+//! the [`events`] module. Events appear in `kubectl describe` and `kubectl events` output and
+//! provide visibility into operator operations.
+//!
+//! Identical events (same object UID, type, reason, and action) within a configurable window
+//! (default: 6 minutes) are automatically deduplicated: the first occurrence creates a new
+//! Event, subsequent ones PATCH the existing Event's `series.count`.
 //!
 //! ### Defining Event Reasons
 //!
@@ -248,6 +253,21 @@
 //!
 //! **Important:** Events never fail reconciliation. The `emit()` method logs errors as warnings
 //! but does not propagate them. Use `try_emit()` if you need explicit error handling.
+//!
+//! **RBAC:** Your operator's ClusterRole needs `apiGroups: ["events.k8s.io"]`, resources
+//! `["events"]`, verbs `["create", "patch"]`.
+//!
+//! **Viewing events:** Use `kubectl events -n <namespace>` (not `kubectl get events`) to see
+//! `events.k8s.io/v1` events with dedup counts.
+//!
+//! ### Customizing the Deduplication Window
+//!
+//! ```rust,ignore
+//! use std::time::Duration;
+//!
+//! let event_recorder = EventRecorder::new(event_api_provider, "my-operator")
+//!     .with_cache_ttl(Duration::from_secs(10 * 60)); // 10 minutes instead of default 6
+//! ```
 //!
 //! ### Testing with MockEventRecorder
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@
 //! ```rust,ignore
 //! use kuberator::events::{EventRecorder, EventData, EmitEvent};
 //! use kuberator::cache::StaticApiProvider;
-//! use k8s_openapi::api::core::v1::Event;
+//! use k8s_openapi::api::events::v1::Event;
 //!
 //! // Setup event API provider (once at startup)
 //! let event_api_provider = Arc::new(StaticApiProvider::new(
@@ -274,7 +274,7 @@
 //! recorder.emit(&resource, EventData::normal(TestReason::Created, "test")).await;
 //!
 //! let events = recorder.events();
-//! assert_eq!(events[0].1, TestReason::Created);
+//! assert_eq!(events[0].reason, TestReason::Created);
 //! # });
 //! ```
 //!


### PR DESCRIPTION
## Summary

- Migrate `EventRecorder` from legacy `core/v1/Event` to `events.k8s.io/v1` Event API
- Add in-memory deduplication cache: first occurrence creates a new Event, subsequent identical events (same UID, type, reason, action) increment the series count via PATCH
- Configurable cache TTL (default 6 min) with builder pattern (`with_cache_ttl`)
- Update `MockEventRecorder` with `RecordedEvent<R>` struct and dedup behavior matching the real recorder
- Bump version to 0.4.0

## Breaking changes

- `ProvideApi<core::v1::Event>` -> `ProvideApi<events::v1::Event>`
- `MockEventRecorder::events()` returns `Vec<RecordedEvent<R>>` instead of `Vec<(String, R, String)>`
- RBAC: consumers must grant `create` + `patch` on `events.k8s.io` instead of `""` (core)

## Test plan

- [x] All unit tests pass
- [x] Clippy clean
- [x] Formatting clean
- [x] Manual E2E: first error creates event, repeated errors increment count