### PR TITLE
chore(deps): update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 repository = "https://github.com/maoertel/kuberator"
 
 [dependencies]
-kube = { version = "2.0", features = ["runtime", "derive"] }
-k8s-openapi = { version = "0.26", features = ["latest"] }
+kube = { version = "3.1", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.27", features = ["latest"] }
 
 futures = { version = "0.3", default-features = false }
 async-trait = "0.1"
@@ -26,8 +26,7 @@ tracing = "0.1"
 thiserror = "2.0"
 anyhow = "1.0"
 
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,12 +77,11 @@ mod tests {
     #[test]
     fn test_kube_error_conversion() {
         // Given: A kube::Error
-        let kube_err = kube::Error::Api(kube::core::ErrorResponse {
-            status: "Failure".to_string(),
-            message: "test error".to_string(),
-            reason: "BadRequest".to_string(),
-            code: 400,
-        });
+        let kube_err = kube::Error::Api(
+            kube::core::Status::failure("test error", "BadRequest")
+                .with_code(400)
+                .boxed(),
+        );
 
         // When: Converting to Error
         let error: Error = kube_err.into();
@@ -157,12 +156,11 @@ mod tests {
     #[test]
     fn test_finalizer_error_add_finalizer() {
         // Given: A FError::AddFinalizer with kube error
-        let kube_err = kube::Error::Api(kube::core::ErrorResponse {
-            status: "Failure".to_string(),
-            message: "cannot add finalizer".to_string(),
-            reason: "Conflict".to_string(),
-            code: 409,
-        });
+        let kube_err = kube::Error::Api(
+            kube::core::Status::failure("cannot add finalizer", "Conflict")
+                .with_code(409)
+                .boxed(),
+        );
         let ferror: FError<std::io::Error> = FError::AddFinalizer(kube_err);
 
         // When: Converting to Error
@@ -180,12 +178,11 @@ mod tests {
     #[test]
     fn test_finalizer_error_remove_finalizer() {
         // Given: A FError::RemoveFinalizer with kube error
-        let kube_err = kube::Error::Api(kube::core::ErrorResponse {
-            status: "Failure".to_string(),
-            message: "cannot remove finalizer".to_string(),
-            reason: "Conflict".to_string(),
-            code: 409,
-        });
+        let kube_err = kube::Error::Api(
+            kube::core::Status::failure("cannot remove finalizer", "Conflict")
+                .with_code(409)
+                .boxed(),
+        );
         let ferror: FError<std::io::Error> = FError::RemoveFinalizer(kube_err);
 
         // When: Converting to Error

--- a/src/events/recorder.rs
+++ b/src/events/recorder.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use chrono::Utc;
 use k8s_openapi::api::core::v1::ObjectReference;
 use k8s_openapi::api::events::v1::Event;
 use k8s_openapi::api::events::v1::EventSeries;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::jiff::Timestamp;
 use kube::api::Patch;
 use kube::api::PatchParams;
 use kube::api::PostParams;
@@ -132,7 +132,7 @@ where
 
     async fn patch_existing(&self, events_api: &Api<Event>, key: &EventKey, cached: &CachedEvent) -> Result<()> {
         let new_count = cached.count + 1;
-        let now = Utc::now();
+        let now = Timestamp::now();
 
         let patch = EventSeriesPatch {
             series: EventSeries {
@@ -163,8 +163,8 @@ where
         namespace: &str,
         regarding: ObjectReference,
     ) -> Result<()> {
-        let now = Utc::now();
-        let event_name = format!("{name}.{:x}", now.timestamp_micros() as u64);
+        let now = Timestamp::now();
+        let event_name = format!("{name}.{:x}", now.as_microsecond() as u64);
 
         let action = event.action.unwrap_or_else(|| event.reason.to_string());
         let note = truncate_note(event.message, Self::MAX_NOTE_LENGTH);


### PR DESCRIPTION
## Summary

Updates all dependencies to their latest versions. Semver-compatible bumps (anyhow, chrono, futures, schemars, thiserror, tokio, tracing, and dev-deps) come through the lockfile; three manifest bumps required code changes:

- **kube 2.0 → 3.1** — `kube::Error::Api` now wraps a boxed `Status` with additional fields. The error-conversion tests now build it via `Status::failure(..).with_code(..).boxed()` instead of the deprecated `ErrorResponse` struct literal.
- **k8s-openapi 0.26 → 0.27** — time types migrated from `chrono` to `jiff`. The event recorder now uses `k8s_openapi::jiff::Timestamp` instead of `chrono::Utc`. This removed the last use of `chrono`, so it is dropped as a direct dependency.
- **strum 0.27 → 0.28** — no code changes required.

## Verification

- `cargo build` ✅
- `cargo clippy --all-targets` ✅ (clean)
- `cargo fmt` ✅
- `cargo test` ✅ — 68 unit/integration tests + 9 doctests pass
- `cargo outdated --root-deps-only` → "All dependencies are up to date"