### PR TITLE
chore: bump version to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-12
+
+### Changed
+- Updated all dependencies to their latest versions
+- **BREAKING**: Bumped `kube` 2.0 → 3.1; `kube::Error::Api` now wraps a boxed `Status`
+- **BREAKING**: Bumped `k8s-openapi` 0.26 → 0.27; time types migrated from `chrono` to `jiff`
+- Bumped `strum` 0.27 → 0.28
+
+### Removed
+- Dropped the direct `chrono` dependency (replaced by `jiff` via `k8s-openapi`)
+
 ## [0.4.0] - 2026-02-13
 
 ### Added
@@ -120,7 +131,8 @@ see the [commit history](https://github.com/maoertel/kuberator/commits/main).
 
 ---
 
-[Unreleased]: https://github.com/maoertel/kuberator/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/maoertel/kuberator/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/maoertel/kuberator/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/maoertel/kuberator/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/maoertel/kuberator/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/maoertel/kuberator/compare/v0.2.1...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuberator"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Mathias Oertel <mathias.oertel@gmail.com>"]
 description = "A Kubernetes operator framework in Rust"


### PR DESCRIPTION
## Summary

Releases the dependency updates from #26 as `v0.4.1`.

- Bumps `version` in `Cargo.toml` from `0.4.0` to `0.4.1`.
- Adds a `0.4.1` entry to `CHANGELOG.md`.

## Note

The dependency updates include `kube` 2.0 → 3.1 and `k8s-openapi` 0.26 → 0.27, which are technically breaking for downstream consumers (the `kube::Error::Api` shape changed; time types moved to `jiff`). Per request this is released as a patch (`0.4.1`).